### PR TITLE
Add gitattributes to ensure unix line endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# ensure unix line endings on windows for files that need them.
+*.sh eol=lf
+codelists/* eol=lf


### PR DESCRIPTION
 For codelists and shell scripts